### PR TITLE
temporarily add --label back to create-release sub command

### DIFF
--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -76,6 +76,9 @@ let private createReleaseOnGithub (arguments:ParseResults<Arguments>) =
         (Paths.Repository.Split("/") |> Seq.toList)
         @ ["create-release"
            "--version"; currentVersion
+           "--label"; "enhancements"; "New Features"
+           "--label"; "bug"; "Bug Fixes"
+           "--label"; "documentation"; "Docs Improvements"
         ] @ tokenArgs
         
     exec "dotnet" (dotnetRun @ ["--"; ] @ releaseArgs) |> ignore

--- a/src/release-notes/Arguments.fs
+++ b/src/release-notes/Arguments.fs
@@ -16,7 +16,7 @@ type Arguments =
     | [<SubCommand; CustomCommandLine("create-release"); CliPrefix(CliPrefix.None)>] CreateRelease of ParseResults<CreateReleaseArguments>
     | [<Inherit;Mandatory>]Version of string
     | [<Inherit>]Token of string
-    | Label of label:string * description:string
+    | [<Inherit>]Label of label:string * description:string
     | OldVersion of string
     | ReleaseLabelFormat of string
     | UncategorizedHeader of string


### PR DESCRIPTION
In the long run `create-release` should no longer generate the notes again but take them (and more information e.g from nullean/assembly-differ) as files to read on the command line.