### PR TITLE
Adds support to format to AsciiDoc

### DIFF
--- a/src/release-notes/Arguments.fs
+++ b/src/release-notes/Arguments.fs
@@ -18,6 +18,8 @@ type CurrentVersionArguments =
             match s with
             | Query _ -> "An anchor query, M.N, M.x, or master. will find the current and next patch, minor, major respectfully"
 
+type Format = Markdown | AsciiDoc
+
 type Arguments =
     | [<MainCommand;Mandatory;Inherit; CliPrefix(CliPrefix.None);>] Repository of owner:string * repository_name:string
     | [<SubCommand; CustomCommandLine("apply-labels"); CliPrefix(CliPrefix.None)>] ApplyLabels 
@@ -30,6 +32,7 @@ type Arguments =
     | OldVersion of string
     | ReleaseLabelFormat of string
     | BackportLabelFormat of string
+    | Format of Format
     | UncategorizedHeader of string
     | Output of string
     
@@ -54,6 +57,7 @@ type Arguments =
                 sprintf "The backport label format, defaults to 'Backport BRANCH`, BRANCH will be calculated from the version" 
             | UncategorizedHeader _ -> "The header to use in the markdown for uncategorized issues/prs"
             | Output _ -> "write the release notes to a file as well as standard out, VERSION will be replaced by the actual version"
+            | Format _ -> "The format in which to print the results, can be markdown and asciidoc"
 
 type GitHubRepository(owner, repository) =
     member this.Owner = owner
@@ -79,6 +83,7 @@ type ReleaseNotesConfig =
         GenerateReleaseOnGithub: bool
         ReleaseBodyFiles: string list option
         VersionQuery: string option
+        Format: Format
     }
 
 

--- a/src/release-notes/GithubItem.fs
+++ b/src/release-notes/GithubItem.fs
@@ -24,6 +24,19 @@ type GitHubItem(issue: Issue, relatedIssues: int list) =
         |> ignore                  
         builder.ToString()
         
+    member this.TitleAsciiDoc githubUrl =
+        if issue.PullRequest = null then
+            sprintf "* %s %sissues/%i[#%i]" issue.Title githubUrl issue.Number issue.Number
+        else
+            let related =
+                if relatedIssues.Length > 0 then
+                    relatedIssues
+                    |> List.map(fun i -> sprintf "%sissues/%i[#%i]" githubUrl i i)
+                    |> String.concat ", "
+                    |> sprintf " (%s: %s)" (if relatedIssues.Length = 1 then "issue" else "issues")
+                else ""
+            sprintf "* %s %spull/%i[#%i] %s" issue.Title githubUrl issue.Number issue.Number related
+        
     member this.Labels = issue.Labels   
     member this.Number = issue.Number
 

--- a/src/release-notes/OutputWriter.fs
+++ b/src/release-notes/OutputWriter.fs
@@ -7,6 +7,13 @@ open System.Text
 type OutputWriter(output: string option) =
     let stdout = Console.Out
     let sb = new StringBuilder()
+    do
+        output |> Option.iter (fun o ->
+            printfn ""
+            printfn "Building %s" o
+            printfn "-------------------"   
+        )
+    
     member this.EmptyLine () =
         stdout.WriteLine()
         sb.AppendLine() |> ignore

--- a/src/release-notes/Program.fs
+++ b/src/release-notes/Program.fs
@@ -159,9 +159,107 @@ let private writeMarkDownReleaseNotes (config:ReleaseNotesConfig) (client:GitHub
     sprintf "### [View the full list of issues and PRs](%sissues?utf8=%%E2%%9C%%93&q=label%%3A%s)" config.GitHub.Url releasedLabel
     |> writer.WriteLine
     writer.ToString()
+    
+let private writeAsciiDocReleaseNotes (config:ReleaseNotesConfig) (client:GitHubClient) oldVersion =
+    
+    
+    config.Output |> Option.iter (fun output ->
+        let d = Directory.CreateDirectory(output)
+        let path f = FileInfo <| Path.Combine(d.FullName, f)
+        let cv = SemVer.parse config.Version
+        
+        let releaseNotes = path "release-notes.asciidoc"
+        
+        let generatedNotes = path <| sprintf "release-notes-%O-generated.asciidoc" cv
+        let humanNotes = path <| sprintf "release-notes-%O-human.asciidoc" cv
+        
+        let writeHuman () =
+            use writer = new OutputWriter(Some humanNotes.FullName)
+            writer.WriteLine <| sprintf ""
+        let writeGenerated () =
+            use writer = new OutputWriter(Some generatedNotes.FullName)
+            writer.WriteLine <| sprintf ""
+            let releasedLabel = Labeler.releaseLabel config.Version config.ReleaseLabelFormat  
+            let groupedClosedIssues = GithubScanner.getClosedIssues config client releasedLabel
+            for kv in groupedClosedIssues do
+                let header = kv.Key.ToLowerInvariant().Replace(" ", "-")
+                let value = config.Labels.[kv.Key] 
+                
+                sprintf @"[float]
+[[%s]]
+=== %s"             header value |> writer.WriteLine
+                writer.EmptyLine ()
+                for issue in kv.Value do
+                    sprintf "- %s" (issue.TitleAsciiDoc config.GitHub.Url) |> writer.WriteLine
+                writer.EmptyLine ()
+            writer.WriteLine ""
+        
+        if not humanNotes.Exists then writeHuman()
+        writeGenerated()
+            
+        let versionNotes = path <| sprintf "release-notes-%O.asciidoc" cv
+        let writeVersioned () =
+            use writer = new OutputWriter(Some versionNotes.FullName)
+            writer.WriteLine <| sprintf """[float]
+[[release-notes-%O]]
+=== Release-Notes %O
+
+include::%s[]
+include::%s[]
+
+"""                 cv cv humanNotes.Name generatedNotes.Name
+
+        writeVersioned()
+        
+        //write release notes landing page
+        
+        let currentPatchReleases =
+            seq { 0 .. Convert.ToInt32(cv.Patch) } |> Seq.rev
+            |> Seq.map(fun patch -> SemVer.parse <| sprintf "%i.%i.%i" cv.Major cv.Minor patch)
+            |> Seq.toList
+        
+        use writer = new OutputWriter(Some releaseNotes.FullName)
+        writer.WriteLine <| sprintf @"[[release-notes]]
+= Release notes
+
+[partintro]
+--
+Review important information about %i.%i.x releases.
+
+* <<release-notes-7.12.0>>
+--
+"           cv.Major cv.Minor
+        
+        currentPatchReleases |> List.iter(fun (v:SemVerInfo) ->
+            let fileName = sprintf "release-notes-%O.asciidoc" v
+            let versionReleaseNotes = path fileName
+            if versionReleaseNotes.Exists then
+                writer.WriteLine <| sprintf "\n\ninclude::%s[]\n\n" fileName
+            else
+                let ghRelease =
+                    sprintf "%s/releases/tag/%s"
+                        config.GitHub.Repository
+                        (Labeler.releaseLabel (v.ToString()) config.ReleaseLabelFormat)
+                    
+                writer.WriteLine <| sprintf """[float]
+[[release-notes-%O]]
+=== Release-Notes %O
+%s[Available on github]
+
+"""                 v v ghRelease
+            
+               
+        )
+    )
+    ignore()
+
 
 let private writeReleaseNotes (config:ReleaseNotesConfig) (client:GitHubClient) oldVersion =
-    writeMarkDownReleaseNotes config client oldVersion
+    match config.Format with
+    | Markdown ->
+        writeMarkDownReleaseNotes config client oldVersion |> ignore
+    | AsciiDoc ->
+        writeAsciiDocReleaseNotes config client oldVersion
 
 let run (config:ReleaseNotesConfig) =
     let client = GitHubClient(ProductHeaderValue("ReleaseNotesGenerator"))
@@ -217,6 +315,13 @@ let main argv =
             let version = p.GetResult Version
             let oldVersion = p.TryGetResult OldVersion
             
+            let format = p.TryGetResult Format |> Option.defaultValue Markdown
+//                match p.TryGetResult Format with
+//                | Some "asciidoc" | Some "adoc" -> AsciiDoc
+//                | Some "md" | Some "markdown"
+//                | None -> Markdown
+//                | Some v -> failwithf "'%s' is not a supported format" v
+            
             let uncategorizedLabel = "Uncategorized" 
             let uncategorizedHeader = p.TryGetResult UncategorizedHeader |> Option.defaultValue uncategorizedLabel
             
@@ -255,6 +360,7 @@ let main argv =
                 GenerateReleaseOnGithub = generateRelease
                 ReleaseBodyFiles = bodyFilePaths
                 VersionQuery = versionQuery
+                Format = format
             }
             run config
         with e ->

--- a/src/release-notes/release-notes.fsproj
+++ b/src/release-notes/release-notes.fsproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="6.0.0" />
+    <PackageReference Include="Argu" Version="6.1.1" />
     <PackageReference Include="Octokit" Version="0.43.0" />
     <PackageReference Include="Fake.Core.SemVer" Version="5.15.0" />
   </ItemGroup>


### PR DESCRIPTION
This enables support for AsciiDoc output.

This will generate multiple output files that are linked.

- release-notes.asciidoc
	- release-notes-VERSION.asciidoc
		- release-notes-VERSION-human.asciidoc
		- release-notes-VERSION-generated.asciidoc

If VERSION is e.g 7.12.4 in the overview all versions down to 7.12.0 are
linked highest to lowest. If no version specific notes exists for the previous versions
they will link to github releases.

The human files are empty by default and only generated if they don't
exists. This allows you to write human readable highlights in addition
to the generated notes.
