### PR TITLE
Introduce flag to control tag format.

### DIFF
--- a/src/release-notes/Arguments.fs
+++ b/src/release-notes/Arguments.fs
@@ -30,6 +30,7 @@ type Arguments =
     | [<Inherit>]Token of string
     | [<Inherit>]Label of label:string * description:string
     | OldVersion of string
+    | ReleaseTagFormat of string
     | ReleaseLabelFormat of string
     | BackportLabelFormat of string
     | Format of Format
@@ -51,6 +52,8 @@ type Arguments =
             | Repository _ -> "Repository to use in <owner> <repos_name> format"
             | Label _ -> "Map Github labels to categorizations, format <label> <description>, can be specified multiple times"
             | OldVersion _ -> "The previous version to generate release notes since, optional the tool will find the previous release"
+            | ReleaseTagFormat _ ->
+                sprintf "The release tag format, defaults to VERSION, VERSION will be replaced by the actual version" 
             | ReleaseLabelFormat _ ->
                 sprintf "The release label format, defaults to vVERSION, VERSION will be replaced by the actual version" 
             | BackportLabelFormat _ ->
@@ -73,6 +76,7 @@ type ReleaseNotesConfig =
         Token: string option
         Version: string
         OldVersion: string option
+        ReleaseTagFormat: string 
         ReleaseLabelFormat: string 
         BackportLabelFormat: string option 
         UncategorizedLabel: string 

--- a/src/release-notes/Program.fs
+++ b/src/release-notes/Program.fs
@@ -11,7 +11,7 @@ open ReleaseNotes
 open ReleaseNotes.Arguments
 
 let private releaseExists (config:ReleaseNotesConfig) (client:GitHubClient) version =
-    let releaseTag = Labeler.releaseLabel version config.ReleaseLabelFormat  
+    let releaseTag = Labeler.releaseLabel version config.ReleaseTagFormat  
     let existing =
         try
             Some <|
@@ -363,6 +363,7 @@ let main argv =
                 Token = token
                 Version = version
                 OldVersion = oldVersion
+                ReleaseTagFormat = p.TryGetResult ReleaseTagFormat |> Option.defaultValue "VERSION"
                 ReleaseLabelFormat = p.TryGetResult ReleaseLabelFormat |> Option.defaultValue "vVERSION"
                 BackportLabelFormat = p.TryGetResult BackportLabelFormat
                 UncategorizedLabel = uncategorizedLabel


### PR DESCRIPTION
Some repos do VERSION others vVERSION.

The defaults are vVERSION for labels and VERSION for tag
