### PR TITLE
Fix nuget push retry loop hanging forever on GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
       shell: bash
       run:  |
-         until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true; do echo "Retrying"; sleep 1; done;
+         until dotnet nuget push 'build/output/*.nupkg' -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols; do echo "Retrying"; sleep 1; done;
 
     # ghcr.io/nullean/release-notes, matching curb's own tagging: "edge" on every push, plus
     # "latest" and the semver when this push is an exact release tag — see


### PR DESCRIPTION
Fixes CI run [33666135006](https://github.com/nullean/release-notes/actions/runs/33666135006), which never finished.

## Why

`--no-symbols` is a boolean switch in `dotnet nuget push` — it takes no value. The `publish to github package repository` step had a stray trailing `true` after it (`--no-symbols true`), which `dotnet nuget push` parses as a second positional package-path argument instead of a value for the flag. No file named `true` exists, so every invocation fails with:

```
error: File does not exist (true).
```

That failure is inside `until dotnet nuget push ...; do echo "Retrying"; sleep 1; done`, so instead of failing once, it retried the exact same broken command forever — the job just ran until someone cancelled it.

## What

Drops the stray `true`, matching the already-correct form used by `nupkg-validator` and `assembly-rewriter`'s equivalent steps.

## Verify

Confirmed via the failed run's log: package pushes that were new succeeded ("Your package was pushed"), pushes for already-existing versions correctly hit `--skip-duplicate`'s "Conflict" (non-fatal) path, and the loop only ever failed on the trailing `error: File does not exist (true).` — never on an actual push.

Made with [Cursor](https://cursor.com)