### PR TITLE
Bump Proc to 0.14.0, retry dotnet tool restore once on failure

### DIFF
--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -109,7 +109,11 @@ let private generateApiChanges (arguments:ParseResults<Arguments>) =
     let args =
         [
             "assembly-differ"
-            (sprintf "previous-nuget|%s|%s|net10.0" Paths.ToolName currentVersion);
+            // The plain "release-notes" package id is just a DotnetToolSettings.xml v2 shim pointing
+            // at per-RID sub-packages (see generatePackages above) - it ships no managed assembly of
+            // its own, so NuGetAssemblyProvider would find 0 assemblies there. The portable, signed
+            // managed build lives in "release-notes.any" instead.
+            (sprintf "previous-nuget|%s.any|%s|net10.0" Paths.ToolName currentVersion);
             (sprintf "directory|src/%s/bin/Release/net10.0" Paths.ToolName);
             "--target"; "release-notes"; "-f"; "github-comment"; "--output"; output
         ]

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -13,7 +13,16 @@ open ProcNet
 let exec binary args =
     Proc.Exec (binary, args |> List.toArray)
     
-let private restoreTools = lazy(exec "dotnet" ["tool"; "restore"])
+/// dotnet/sdk#53783: on a cold tool-resolver cache (every fresh CI runner, every fresh container),
+/// restoring 2+ RID-specific tool packages in one manifest can misattribute one package's
+/// DotnetToolSettings.xml to another, failing with "The command ... is not contained in the
+/// package ...". The cache is warm after the first attempt, so a bare retry always succeeds -
+/// see https://github.com/dotnet/sdk/issues/53783.
+let private restoreTools =
+    lazy(
+        try exec "dotnet" ["tool"; "restore"]
+        with _ -> exec "dotnet" ["tool"; "restore"]
+    )
 let private currentVersion =
     lazy(
         restoreTools.Value |> ignore

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.0.0" />
     <PackageReference Include="Bullseye" Version="6.0.0" />
-    <PackageReference Include="Proc" Version="0.9.1" />
+    <PackageReference Include="Proc" Version="0.14.0" />
     <PackageReference Include="Fake.Tools.Git" Version="5.15.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Bumps the `Proc` build-script dependency from 0.9.1 to 0.14.0 (latest), matching the semantics (no shell expansion, throws on failure) already assumed elsewhere.
- `dotnet tool restore` now retries once on failure: [dotnet/sdk#53783](https://github.com/dotnet/sdk/issues/53783) causes cold-cache restores of 2+ RID-specific tool packages (`nupkg-validator` and `assembly-differ`, both native-AOT now) to misattribute one package's `DotnetToolSettings.xml` to another. A retry always succeeds since the cache is warm afterward.

## Test plan
- [x] `dotnet build build/scripts/scripts.fsproj -c Release` succeeds.

Made with [Cursor](https://cursor.com)