### PR TITLE
Fix GitHub release creation silently dropping tag_name under Native AOT

### DIFF
--- a/src/release-notes/GitHubReleaseClient.cs
+++ b/src/release-notes/GitHubReleaseClient.cs
@@ -1,0 +1,56 @@
+using System.Net.Http.Headers;
+using System.Text.Json.Serialization;
+
+namespace ReleaseNotes;
+
+/// <summary>
+/// Minimal, source-generated-JSON client for creating a GitHub release directly against the REST API.
+/// </summary>
+/// <remarks>
+/// Octokit.Repository.Release.Create can't be used here: Octokit's SimpleJsonSerializer serializes request
+/// bodies via raw, unannotated reflection (no [DynamicallyAccessedMembers] anywhere in Octokit/SimpleJson.cs),
+/// and under Native AOT trimming the linker strips getter metadata for any property whose accessors have
+/// mixed visibility. NewRelease.TagName is "public get; private set;" - the only such property among every
+/// request model this tool sends - so in an AOT-published build tag_name silently vanishes from the outgoing
+/// JSON while every other field (all plain public get/set) still serializes fine. GitHub then rejects the
+/// request with 422 "tag_name" wasn't supplied, even though the C# call site clearly set it. Everything else
+/// this tool does through Octokit (GetLatest/Get, ReleaseUpdate, labels) uses only plain public get/set
+/// models, so those aren't affected - only the Create path needs this workaround.
+/// </remarks>
+internal static class GitHubReleaseClient
+{
+	public static async Task CreateRelease(HttpClient httpClient, string owner, string repository, string tagName, string? body, string? token)
+	{
+		using var request = new HttpRequestMessage(HttpMethod.Post, $"https://api.github.com/repos/{owner}/{repository}/releases")
+		{
+			Content = System.Net.Http.Json.JsonContent.Create(
+				new GitHubNewReleaseRequest { TagName = tagName, Body = body },
+				GitHubReleaseJsonContext.Default.GitHubNewReleaseRequest)
+		};
+		request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+		request.Headers.UserAgent.Add(new ProductInfoHeaderValue("ReleaseNotesGenerator", "1.0"));
+		request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+		if (token is { Length: > 0 })
+			request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+		using var response = await httpClient.SendAsync(request);
+		if (!response.IsSuccessStatusCode)
+		{
+			var responseBody = await response.Content.ReadAsStringAsync();
+			throw new InvalidOperationException(
+				$"Failed to create GitHub release for tag '{tagName}' on {owner}/{repository}: {(int)response.StatusCode} {response.StatusCode}\n{responseBody}");
+		}
+	}
+}
+
+internal sealed class GitHubNewReleaseRequest
+{
+	[JsonPropertyName("tag_name")]
+	public required string TagName { get; set; }
+
+	[JsonPropertyName("body")]
+	public string? Body { get; set; }
+}
+
+[JsonSerializable(typeof(GitHubNewReleaseRequest))]
+internal partial class GitHubReleaseJsonContext : JsonSerializerContext;

--- a/src/release-notes/ReleaseNotesRunner.cs
+++ b/src/release-notes/ReleaseNotesRunner.cs
@@ -51,7 +51,12 @@ public static class ReleaseNotesRunner
 			await client.Repository.Release.Edit(config.GitHub.Owner, config.GitHub.Repository, existing.Id, new ReleaseUpdate { Body = body.ToString() });
 		}
 		else
-			await client.Repository.Release.Create(config.GitHub.Owner, config.GitHub.Repository, new NewRelease(config.Version) { Body = body.ToString() });
+		{
+			// Not client.Repository.Release.Create() - see GitHubReleaseClient's remarks for why Octokit's
+			// own NewRelease serialization silently drops tag_name under Native AOT.
+			using var httpClient = new HttpClient();
+			await GitHubReleaseClient.CreateRelease(httpClient, config.GitHub.Owner, config.GitHub.Repository, config.Version, body.ToString(), config.Token);
+		}
 	}
 
 	private static async Task<string?> LocateOldVersion(ReleaseNotesConfig config, GitHubClient client)


### PR DESCRIPTION
## What

Creating a GitHub release (`create-release`) from the AOT-published `release-notes` tool has been failing on GitHub's side with:

```
Octokit.ApiValidationException: {"message":"Invalid request.\n\n\"tag_name\" wasn't supplied.","status":"422"}
```

even though the call site (`new NewRelease(config.Version)`) clearly sets it, and `config.Version` is confirmed non-empty.

## Root cause

`Octokit.Internal.SimpleJsonSerializer` serializes request bodies via raw, completely unannotated reflection (`type.GetRuntimeProperties()`, no `[DynamicallyAccessedMembers]` anywhere in `Octokit/SimpleJson.cs` or its reflection helpers). Under Native AOT trimming, the linker can't statically prove which reflected members are needed, so it strips metadata for properties it can't safely classify — in practice, this hits any property with mixed accessor visibility.

`NewRelease.TagName` is `public string TagName { get; private set; }` — the **only** property, across every request model this tool sends (`NewRelease`, `ReleaseUpdate`, `NewLabel`, `LabelUpdate`), with a non-public accessor. Every other property involved is plain `{ get; set; }` and survives trimming fine.

I confirmed the mechanism directly: publishing a minimal repro with IL trimming enabled and calling `SimpleJsonSerializer.Serialize(new NewRelease(...))` throws:
```
System.NullReferenceException
   at Octokit.PropertyOrField..ctor(PropertyInfo propertyInfo)
   at Octokit.Internal.SimpleJsonSerializer.GitHubSerializerStrategy.GetterValueFactory(Type type)
```
because `GetGetterMethodInfo(propertyInfo)` returns `null` for `TagName` once its getter metadata is trimmed. The fully AOT-compiled build (as opposed to plain IL trimming) degrades more gracefully and just silently omits the field from the JSON instead of crashing — which is exactly what GitHub's 422 response showed.

This is unrelated to the Octokit version — `14.0.0` is already latest on NuGet, and the bug is structural (no `JsonSerializerContext`/source-gen support in Octokit's request serialization at all).

## Fix

Bypass Octokit only for the `Create` call — the one place this tool serializes a model with a mixed-visibility property. `GitHubReleaseClient.CreateRelease` POSTs directly via `HttpClient`, using a source-generated `System.Text.Json.JsonSerializerContext` (fully AOT-safe by construction, no reflection at all).

Everything else keeps using Octokit's `GitHubClient` unchanged (`GetLatest`/`Get` for checking existing releases, `Repository.Release.Edit` with `ReleaseUpdate`, and the labeling calls) — those request/response models are all plain public get/set, so they aren't affected by this trimming behavior.

## Verification

Built a standalone repro of the exact `JsonContent.Create(..., JsonSerializerContext)` pattern used here, published it fully native-AOT for `linux-x64` in a clean `mcr.microsoft.com/dotnet/sdk:10.0` container, and posted it against a local `HttpListener`:
```
SERVER RECEIVED: {"tag_name":"0.14.1-aot-test","body":"hello"}
STATUS: Created
```
confirming `tag_name` now survives AOT compilation end-to-end.

## Also included

Rebased onto current `master`, which already carries the `.any`-package `generateApiChanges` fix from a previous PR (turned out cherry-picking it here was a no-op — it's already there).

Made with [Cursor](https://cursor.com)